### PR TITLE
Add support for multiple tables and more

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,23 @@
+PATH
+  remote: .
+  specs:
+    csv_query (1.0.4)
+      sqlite3
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    minitest (5.6.1)
+    rake (10.4.2)
+    sqlite3 (1.3.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  csv_query!
+  minitest
+  rake
+
+BUNDLED WITH
+   1.10.0.pre.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Assumptions
 
 The first row of data is assumed to be headers.
 
-All fields are created as `VARCHAR(255)`, which hopefully works for most cases.
+All fields are created as `TEXT`, which hopefully works for most cases.
 
 Behind the scenes
 -----------------

--- a/lib/csv_query.rb
+++ b/lib/csv_query.rb
@@ -1,2 +1,5 @@
 module CsvQuery
 end
+
+require 'csv_query/command_line'
+require 'csv_query/database'

--- a/lib/csv_query/database.rb
+++ b/lib/csv_query/database.rb
@@ -1,37 +1,62 @@
 require 'sqlite3'
+require 'csv_query/table'
 
 module CsvQuery
-  # Wraps a SQLite in-memory database with a single table named csv.
+  # Wraps a SQLite in-memory database with a single table named csv by default if you pass in only a csv to initialize.
+  # Don't pass in a CSV and use #create_table and #import_data_from_csv to to perform more complex multi-table loads.
   class Database
-    attr_reader :database
+    attr_accessor :sqlite_database
+    alias_method :database, :sqlite_database # TODO: Can be removed by repo maintainer at version upgrade?
 
-    def initialize(csv)
-      @database = SQLite3::Database.new(':memory:')
-      @columns = csv.headers
-      create_table(@columns)
+    def initialize(default_csv_to_create_table_for=nil)
+      @tables = []
+      @sqlite_database = SQLite3::Database.new(':memory:')
+
+      create_table(default_csv_to_create_table_for, 'csv') if !default_csv_to_create_table_for.nil?
     end
 
-    def import_data_from_csv(csv)
-      columns = csv.headers
+    def create_table(csv, table_name)
+      CsvQuery::Table.new(self, csv, table_name).create_table
+    end
 
-      sql = "INSERT INTO csv VALUES (#{(['?'] * columns.size).join(',')})"
-      statement = database.prepare(sql)
+    def import_data_from_csv(csv, table_name='csv')
+      CsvQuery::Table.new(self, csv, table_name).import_data_from_csv
+    end
 
-      csv.each do |row|
-        statement.execute(row.fields)
-      end
+    def load_csv(csv, table_name)
+      table = CsvQuery::Table.new(self, csv, table_name)
+      table.create_table
+      table.import_data_from_csv
     end
 
     # Returns the results of sql. First row of the resultset contains the column names
     def query(sql)
-      database.execute2(sql)
+      @sqlite_database.execute2(sql)
     end
 
-    private
+    def query_hashes(sql)
+      old_value = @sqlite_database.results_as_hash
+      begin
+        @sqlite_database.results_as_hash = true
+        hashes = @sqlite_database.execute(sql)
 
-    def create_table(column_names)
-      column_definitions = column_names.collect { |name| "\"#{name}\" VARCHAR(255)" }
-      database.execute "CREATE TABLE csv (#{column_definitions.join(", ")})"
+        cleanup_sqlite_hashes!(hashes)
+
+        hashes
+      ensure
+        @sqlite_database.results_as_hash = old_value
+      end
+    end
+
+    protected
+
+    # Not sure why, but in addition to column names, you also get integer indexes as keys... prefer only string
+    # keys that are the column names.
+    def cleanup_sqlite_hashes!(hashes)
+      hashes.each do |h|
+        integer_keys = h.keys.select{|k| k.is_a? Numeric }
+        integer_keys.each{|k| h.delete(k)}
+      end
     end
   end
 end

--- a/lib/csv_query/table.rb
+++ b/lib/csv_query/table.rb
@@ -1,0 +1,41 @@
+require 'sqlite3'
+
+module CsvQuery
+  class Table < Struct.new(:database, :csv, :table_name)
+    class EmptyCsvHeadersError < RuntimeError; end
+
+    def sqlite_database
+      database.sqlite_database
+    end
+
+    def column_names
+      @csv_headers ||= csv.headers
+    end
+
+    def import_data_from_csv
+      insert_statement = sqlite_database.prepare(build_insert_sql)
+
+      sqlite_database.transaction do
+        csv.each do |row|
+          insert_statement.execute(row.fields)
+        end
+      end
+    end
+
+    def build_insert_sql
+      "INSERT INTO #{table_name} VALUES (#{(['?'] * column_names.size).join(',')})"
+    end
+
+    def create_table
+      if csv.empty?
+        # Ruby's CSV lib seems to ignore headers if there are no data rows
+        raise EmptyCsvHeadersError, "the CSV has no detected headers - needs at least one row to load headers"
+      end
+
+      column_definitions = column_names.collect { |name| "\"#{name}\" TEXT" }
+      sqlite_database.execute "CREATE TABLE #{table_name} (#{column_definitions.join(", ")})"
+    end
+
+  end
+
+end

--- a/test/csv_query/database_test.rb
+++ b/test/csv_query/database_test.rb
@@ -15,13 +15,13 @@ describe CsvQuery::Database do
   describe ".new" do
     it "creates SQLite database" do
       database = build_database
-      database.database.class.must_equal(SQLite3::Database)
+      database.sqlite_database.class.must_equal(SQLite3::Database)
     end
 
     it "creates a database table" do
       database = build_database
 
-      columns = database.database.table_info("csv")
+      columns = database.sqlite_database.table_info("csv")
       columns.collect { |column| column["name"] }.must_equal(["Foo"])
     end
   end
@@ -31,7 +31,7 @@ describe CsvQuery::Database do
       database = build_database
       database.import_data_from_csv(csv_data)
 
-      results = database.database.query("SELECT * FROM csv")
+      results = database.sqlite_database.query("SELECT * FROM csv")
       results.to_a.must_equal([["Bar"]])
     end
   end


### PR DESCRIPTION
I am using your gem to load dozens of CSV tables and query them easily, so made it easier to do that via ::Database.  Converted VARCHAR(255) to TEXT.  All bulk inserts are via transaction now, which has some performance benefit when I override the sqlite database to be stored on disk.  Added #query_hashes, my favorite-er way to get rows.  Renamed accessor to sqlite_database because it is confusing to init ::Database and then call database.database.

Not sure if my Gemfile.lock being committed is a best-practice for gems, though it makes sense for Rails projects.  May want to take this out and .gitignore it?
